### PR TITLE
Allow Deletion of Secrets from Secret List View

### DIFF
--- a/frontend/client/views/secrets/index.vue
+++ b/frontend/client/views/secrets/index.vue
@@ -117,7 +117,7 @@
                   <!-- View-only -->
                   <td v-else>
                     {{ entry.desc }}
-                  </td>                                  
+                  </td>
 
                   <td width="68">
                     <a v-if="editMode && currentPathType === 'Secret'" @click="deleteItem(index)">

--- a/frontend/client/views/secrets/index.vue
+++ b/frontend/client/views/secrets/index.vue
@@ -117,12 +117,18 @@
                   <!-- View-only -->
                   <td v-else>
                     {{ entry.desc }}
-                  </td>
+                  </td>                                  
 
                   <td width="68">
                     <a v-if="editMode && currentPathType === 'Secret'" @click="deleteItem(index)">
                     <span class="icon">
                       <i class="fa fa-times-circle"></i>
+                    </span>
+                    </a>
+
+                    <a v-if="currentPathType === 'Path' && entry.type === 'Secret'" @click="deleteSecret(currentPath + entry.path)">
+                    <span class="icon">
+                      <i class="fa fa-trash-o"></i>
                     </span>
                     </a>
                   </td>
@@ -464,9 +470,10 @@ export default {
       })
     },
 
-    deleteSecret: function () {
+    deleteSecret: function (path) {
       // check if current path is valid
-      if (!this.currentPath.includes('/')) {
+
+      if (!path.includes('/')) {
         this.$notify({
           title: 'Invalid',
           message: 'Cannot delete a mount',
@@ -476,7 +483,7 @@ export default {
       }
 
       // recursive deletion may come later, but not now
-      if (this.currentPath.endsWith('/')) {
+      if (path.endsWith('/')) {
         this.$notify({
           title: 'Invalid',
           message: 'Cannot delete a path',
@@ -486,7 +493,7 @@ export default {
       }
 
       // request deletion of secret
-      this.$http.delete('/api/secrets?path=' + this.currentPath, {
+      this.$http.delete('/api/secrets?path=' + path, {
         headers: {'X-CSRF-Token': this.csrf}
       })
       .then((response) => {
@@ -496,7 +503,13 @@ export default {
           type: 'success'
         })
         this.editMode = false
-        this.tableData = []
+        if (path === this.currentPath || path === undefined) {
+          // return to parent view and refresh table data
+          this.changePath(this.currentPath.substring(0, this.currentPath.lastIndexOf('/') + 1))
+        } else {
+          // refresh table data if deleting from list
+          this.changePath(this.currentPath)
+        }
       })
       .catch((error) => {
         this.$onError(error)
@@ -514,6 +527,10 @@ export default {
 
   .control .button {
     margin: inherit;
+  }
+
+  .fa-trash-o {
+    color: red;
   }
 
   .fa-times-circle {


### PR DESCRIPTION
- Utilized existing key-value pair deletion column and added additional logic
around dynamic classing to determine which delete icon to display
- Refactored deleteItem logic to call separate helper functions based off
the specific type of item to delete
- Added ability to delete a specific secret given its path
- Deleting a secret from the secret view now returns the view to
the parent directory upon completion
- Deleteing a secret from the secret list view will update the list