### PR TITLE
Added default sort by `path ASC`

### DIFF
--- a/frontend/client/views/secrets/index.vue
+++ b/frontend/client/views/secrets/index.vue
@@ -321,8 +321,8 @@ export default {
       selectedRows: [],
       lastSelectedRow: 0,
       sortKey: {
-        key: '',
-        order: ''
+        key: 'path',
+        order: 'asc'
       }
     }
   },


### PR DESCRIPTION
More often than not people tend to see some sorting by default.

I think it would be reasonable to assume that the default sort by path is a good and convenient default (I am open to discussion though).