### PR TITLE
serve a valid certificate chain when pulling certs from vault pki

### DIFF
--- a/vault/pki.go
+++ b/vault/pki.go
@@ -26,18 +26,23 @@ func FetchCertificate(path string, body map[string]interface{}) (*tls.Certificat
     if !ok {
         return nil, errors.New("Certificate not found in response")
     }
+    issuingCACertRaw, ok := resp.Data["issuing_ca"]
+    if !ok {
+        return nil, errors.New("Issuing CA Certificate not found in response")
+    }
     keyRaw, ok := resp.Data["private_key"]
     if !ok {
         return nil, errors.New("Private key not found in response")
     }
 
     cert, ok := certRaw.(string)
+    issuing_ca_cert, ok := issuingCACertRaw.(string)
     key, ok := keyRaw.(string)
-    if cert == "" || key == "" {
-        return nil, errors.New("Cert and key could not be asserted to string")
+    if cert == "" || key == "" || issuing_ca_cert == "" {
+        return nil, errors.New("Cert, Issuing CA Cert, and Key could not be asserted to string")
     }
 
-    pair, err := tls.X509KeyPair([]byte(cert), []byte(key))
+    pair, err := tls.X509KeyPair([]byte(cert + "\n" + issuing_ca_cert), []byte(key))
     if err != nil {
         return nil, err
     }


### PR DESCRIPTION
If the Vault PKI backend is an intermediate, this is needed to properly verify TLS from a trusted Root Certificate Authority.